### PR TITLE
A module for FOL notations within TRAHKTENBROT

### DIFF
--- a/theories/TRAKHTENBROT/BPCP_SigBPCP.v
+++ b/theories/TRAKHTENBROT/BPCP_SigBPCP.v
@@ -28,6 +28,8 @@ From Undecidability.Shared.Libs.DLW.Wf
 From Undecidability.TRAKHTENBROT
   Require Import notations utils bpcp fol_ops fo_sig fo_terms fo_logic fo_sat.
 
+Import fol_notations.
+
 Set Implicit Arguments.
 
 (* * Reduction from BPCP to specialized FSAT *)
@@ -66,16 +68,16 @@ Section BPCP_FIN_DEC_EQ_SAT.
 
   Notation lb2term := (fun l => l⤜e).
 
-  Local Definition phi_P      := ∀'∀' £1 ⧓ £0 ⤑ £1 ≢ ∗ ⟑ £0 ≢ ∗.
+  Local Definition phi_P      := ∀∀ £1 ⧓ £0 ⤑ £1 ≢ ∗ ⟑ £0 ≢ ∗.
 
-  Local Definition lt_irrefl  := ∀' ¬ £0 ≺ £0.
-  Local Definition lt_trans   := ∀'∀'∀' £2 ≺ £1 ⤑ £1 ≺ £0 ⤑ £2 ≺ £0.
+  Local Definition lt_irrefl  := ∀ ¬ £0 ≺ £0.
+  Local Definition lt_trans   := ∀∀∀ £2 ≺ £1 ⤑ £1 ≺ £0 ⤑ £2 ≺ £0.
 
   Local Definition phi_lt     := lt_irrefl ⟑ lt_trans.
 
-  Local Definition eq_neq b   := ∀' b⤚£0 ≢ e.
-  Local Definition eq_inj b   := ∀'∀' b⤚£1 ≢ ∗ ⤑ b⤚£1 ≡ b⤚ £0⤑ £1 ≡ £0.
-  Local Definition eq_real    := ∀'∀' true⤚£1 ≡ false⤚£0 ⤑ true⤚£1 ≡ ∗ ⟑ false⤚£0 ≡ ∗.
+  Local Definition eq_neq b   := ∀ b⤚£0 ≢ e.
+  Local Definition eq_inj b   := ∀∀ b⤚£1 ≢ ∗ ⤑ b⤚£1 ≡ b⤚ £0⤑ £1 ≡ £0.
+  Local Definition eq_real    := ∀∀ true⤚£1 ≡ false⤚£0 ⤑ true⤚£1 ≡ ∗ ⟑ false⤚£0 ≡ ∗.
   Local Definition eq_undef b := b⤚∗ ≡ ∗.
 
   Local Definition phi_eq := 
@@ -92,14 +94,14 @@ Section BPCP_FIN_DEC_EQ_SAT.
   Local Definition lt_simul '(s,t) := 
             £1 ≡ s⤜e 
           ⟑ £0 ≡ t⤜e
-       ⟇ ∃'∃' £1 ⧓ £0 
+       ⟇ ∃∃ £1 ⧓ £0 
           ⟑ £3 ≡ s⤜£1 
           ⟑ £2 ≡ t⤜£0 
           ⟑ lt_pair (£1) (£0) (£3) (£2).
 
-  Local Definition phi_simul := ∀'∀' £1 ⧓ £0 ⤑ fol_ldisj (map lt_simul lc).
+  Local Definition phi_simul := ∀∀ £1 ⧓ £0 ⤑ fol_ldisj (map lt_simul lc).
 
-  Definition Σbpcp_encode := phi_P ⟑ phi_lt ⟑ phi_eq ⟑ phi_simul ⟑ ∃' £0 ⧓ £0.
+  Definition Σbpcp_encode := phi_P ⟑ phi_lt ⟑ phi_eq ⟑ phi_simul ⟑ ∃ £0 ⧓ £0.
 
   Section soundness.
 
@@ -332,7 +334,7 @@ Section BPCP_FIN_DEC_EQ_SAT.
                   -- exists y; auto.
     Qed.
 
-    Let sem_phi_solvable : ⟪ ∃' £0 ⧓ £0 ⟫ φ0.
+    Let sem_phi_solvable : ⟪ ∃ £0 ⧓ £0 ⟫ φ0.
     Proof. exists (Some (exist _ l (lt_n_Sn _))); simpl; auto. Qed.
 
     Theorem Sig_bpcp_encode_sound : @fo_form_fin_dec_eq_SAT Σbpcp Σbpcp_eq eq_refl Σbpcp_encode.

--- a/theories/TRAKHTENBROT/Sig0.v
+++ b/theories/TRAKHTENBROT/Sig0.v
@@ -19,6 +19,8 @@ From Undecidability.TRAKHTENBROT
   Require Import notations utils decidable
                  fol_ops fo_sig fo_terms fo_logic fo_sat.
 
+Import fol_notations.
+
 Set Implicit Arguments.
 
 (* * Removal of function symbols from propositional signatures *)

--- a/theories/TRAKHTENBROT/Sig1_1.v
+++ b/theories/TRAKHTENBROT/Sig1_1.v
@@ -18,6 +18,8 @@ From Undecidability.Shared.Libs.DLW.Vec
 From Undecidability.TRAKHTENBROT
   Require Import notations utils fol_ops fo_sig fo_terms fo_logic fo_sat Sig_no_syms.
 
+Import fol_notations.
+
 Set Implicit Arguments.
 
 (* * Removal of function symbols from full monadic signatures *)
@@ -188,7 +190,7 @@ Section Σfull_mon_rem.
   (* We first deals with the non-skolemized reduction *)
 
   Definition Σfull_mon_red : fol_form Σ' :=
-    Σfull_mon_rec A ⟑ ∀' fol_lconj (map Eq lwY).
+    Σfull_mon_rec A ⟑ ∀ fol_lconj (map Eq lwY).
 
   Variable (K : Type).
 
@@ -352,7 +354,7 @@ Section Σfull_mon_rem.
   (* Now we skolemize the right part and show correctness *)
 
   Definition Σfull_mon_red' : fol_form Σ' :=
-    Σfull_mon_rec A ⟑ ∀' fol_mquant fol_ex n (fol_lconj (map Eq' lwY)).
+    Σfull_mon_rec A ⟑ ∀ fol_mquant fol_ex n (fol_lconj (map Eq' lwY)).
 
   Local Lemma Σfull_mon_red'_sound : 
           fo_form_fin_dec_SAT_in Σfull_mon_red K

--- a/theories/TRAKHTENBROT/Sig2_SigSSn1.v
+++ b/theories/TRAKHTENBROT/Sig2_SigSSn1.v
@@ -18,6 +18,8 @@ From Undecidability.Shared.Libs.DLW.Vec
 From Undecidability.TRAKHTENBROT
   Require Import notations utils fol_ops fo_sig fo_terms fo_logic fo_sat.
 
+Import fol_notations.
+
 Set Implicit Arguments.
 
 (* * From binary singleton to a n-ary function and a unary relation *)
@@ -43,8 +45,8 @@ Section Sig2_SigSSn1_encoding.
       | ⊥              => ⊥
       | fol_atom r v   => PSSn1 n (Σrel_var (vec_head v)) (Σrel_var (vec_head (vec_tail v))) 
       | fol_bin b A B  => fol_bin b (Σ2_ΣSSn1 d A) (Σ2_ΣSSn1 d B)
-      | fol_quant fol_fa A  => ∀' PSSn1 n (S d) 0 ⤑ Σ2_ΣSSn1 (S d) A
-      | fol_quant fol_ex A  => ∃' PSSn1 n (S d) 0 ⟑ Σ2_ΣSSn1 (S d) A
+      | fol_quant fol_fa A  => ∀ PSSn1 n (S d) 0 ⤑ Σ2_ΣSSn1 (S d) A
+      | fol_quant fol_ex A  => ∃ PSSn1 n (S d) 0 ⟑ Σ2_ΣSSn1 (S d) A
     end.
 
   Variable (X : Type) (M2  : fo_model Σ2 X).

--- a/theories/TRAKHTENBROT/Sig2_Sign.v
+++ b/theories/TRAKHTENBROT/Sig2_Sign.v
@@ -18,6 +18,8 @@ From Undecidability.Shared.Libs.DLW.Vec
 From Undecidability.TRAKHTENBROT
   Require Import notations fol_ops fo_sig fo_terms fo_logic fo_sat.
 
+Import fol_notations.
+
 Set Implicit Arguments.
 
 (* * From binary singleton to n-ary singleton with n >= 2 *)

--- a/theories/TRAKHTENBROT/Sig_Sig_fin.v
+++ b/theories/TRAKHTENBROT/Sig_Sig_fin.v
@@ -18,6 +18,8 @@ From Undecidability.Shared.Libs.DLW.Vec
 From Undecidability.TRAKHTENBROT
   Require Import notations utils decidable fol_ops fo_sig fo_terms fo_logic fo_sat.
 
+Import fol_notations.
+
 Set Implicit Arguments.
 
 (* * Mapping a formula into a finitary signature *)

--- a/theories/TRAKHTENBROT/Sig_no_syms.v
+++ b/theories/TRAKHTENBROT/Sig_no_syms.v
@@ -18,6 +18,8 @@ From Undecidability.Shared.Libs.DLW.Vec
 From Undecidability.TRAKHTENBROT
   Require Import notations utils fol_ops fo_sig fo_terms fo_logic fo_sat.
 
+Import fol_notations.
+
 Set Implicit Arguments.
 
 (* * Signature reduction for symbol free formulas *) 

--- a/theories/TRAKHTENBROT/Sig_noeq.v
+++ b/theories/TRAKHTENBROT/Sig_noeq.v
@@ -19,6 +19,8 @@ From Undecidability.TRAKHTENBROT
   Require Import notations utils fol_ops fo_sig fo_terms 
                  fo_logic fo_congruence fo_sat.
 
+Import fol_notations.
+
 Set Implicit Arguments.
 
 (* * FSATEQ reduces to FSAT *)

--- a/theories/TRAKHTENBROT/Sig_one_rel.v
+++ b/theories/TRAKHTENBROT/Sig_one_rel.v
@@ -24,6 +24,8 @@ From Undecidability.Shared.Libs.DLW.Vec
 From Undecidability.TRAKHTENBROT
   Require Import notations utils fol_ops fo_sig fo_terms fo_logic.
 
+Import fol_notations.
+
 Set Implicit Arguments.
 
 (* * From several relations to one, arity incremented by 1 *)

--- a/theories/TRAKHTENBROT/Sig_rem_constants.v
+++ b/theories/TRAKHTENBROT/Sig_rem_constants.v
@@ -18,6 +18,8 @@ From Undecidability.Shared.Libs.DLW.Vec
 From Undecidability.TRAKHTENBROT
   Require Import notations utils fol_ops fo_sig fo_terms fo_logic fo_sat.
 
+Import fol_notations.
+
 Set Implicit Arguments.
 
 (* * Removing constant functions from monadic signatures *)

--- a/theories/TRAKHTENBROT/Sig_rem_cst.v
+++ b/theories/TRAKHTENBROT/Sig_rem_cst.v
@@ -18,6 +18,8 @@ From Undecidability.Shared.Libs.DLW.Vec
 From Undecidability.TRAKHTENBROT
   Require Import notations utils decidable fol_ops fo_sig fo_terms fo_logic fo_sat.
 
+Import fol_notations.
+
 Set Implicit Arguments.
 
 (* * From signatures with only constants functions to function symbol free signatures *)

--- a/theories/TRAKHTENBROT/Sig_rem_props.v
+++ b/theories/TRAKHTENBROT/Sig_rem_props.v
@@ -18,6 +18,8 @@ From Undecidability.Shared.Libs.DLW.Vec
 From Undecidability.TRAKHTENBROT
   Require Import notations utils fol_ops fo_sig fo_terms fo_logic fo_sat.
 
+Import fol_notations.
+
 Set Implicit Arguments.
 
 (* * Removing constant propositions from monadic signatures *)

--- a/theories/TRAKHTENBROT/Sig_rem_syms.v
+++ b/theories/TRAKHTENBROT/Sig_rem_syms.v
@@ -18,6 +18,8 @@ From Undecidability.Shared.Libs.DLW.Vec
 From Undecidability.TRAKHTENBROT
   Require Import notations fol_ops fo_sig utils fo_terms fo_logic fo_sat.
 
+Import fol_notations.
+
 Require Import Undecidability.Shared.ListAutomation.
 
 Set Implicit Arguments.
@@ -263,8 +265,8 @@ Section Sig_remove_symbols.
 
   Local Definition fol_rel_fun (s : syms Σ) : 𝔽' := 
        let n := ar_syms _ s
-       in ∀'∀' fol_mquant fol_fa n (   
-              @fol_atom Σ' (inr (inl s)) (£(S n)##vec_set_pos (fun p => £(pos2nat p))) 
+       in ∀∀  fol_mquant fol_fa n (   
+             @fol_atom Σ' (inr (inl s)) (£(S n)##vec_set_pos (fun p => £(pos2nat p))) 
                      ⤑ @fol_atom Σ' (inr (inl s)) (£n##vec_set_pos (fun p => £(pos2nat p)))
                      ⤑ @fol_atom Σ' e (£(S n)##£n##ø) ).
 
@@ -305,7 +307,7 @@ Section Sig_remove_symbols.
  
   Local Definition fol_rel_tot (s : syms Σ) : 𝔽' := 
         let n := ar_syms _ s
-        in fol_mquant fol_fa n (∃' @fol_atom Σ' (inr (inl s)) (£0##vec_set_pos (fun p => £(1+pos2nat p)))). 
+        in fol_mquant fol_fa n (∃ @fol_atom Σ' (inr (inl s)) (£0##vec_set_pos (fun p => £(1+pos2nat p)))). 
 
   Local Fact fol_rel_tot_spec s φ : 
              fol_sem M φ (fol_rel_tot s) 

--- a/theories/TRAKHTENBROT/Sig_uniform.v
+++ b/theories/TRAKHTENBROT/Sig_uniform.v
@@ -18,6 +18,8 @@ From Undecidability.Shared.Libs.DLW.Vec
 From Undecidability.TRAKHTENBROT
   Require Import notations utils fol_ops fo_sig fo_terms fo_logic fo_sat.
 
+Import fol_notations.
+
 Set Implicit Arguments.
 
 (* * Uniformize the arity of relations *)
@@ -165,7 +167,7 @@ Section Sig_uniformize_rels.
            vec_fill_tail n (vec_set_pos (fun p : pos k => £(2+pos2nat p))) (£ 0).
 
       Local Definition fol_uniform_after : fol_form Σ' :=
-           fol_mquant fol_fa k (∀'∀' @fol_atom Σ' r w1 ↔ @fol_atom Σ' r w2).
+           fol_mquant fol_fa k (∀∀ @fol_atom Σ' r w1 ↔ @fol_atom Σ' r w2).
 
       Local Fact fol_uniform_after_spec φ :
            fol_sem M' φ fol_uniform_after 

--- a/theories/TRAKHTENBROT/Sign1_Sig.v
+++ b/theories/TRAKHTENBROT/Sign1_Sig.v
@@ -18,6 +18,8 @@ From Undecidability.Shared.Libs.DLW.Vec
 From Undecidability.TRAKHTENBROT
   Require Import notations utils fol_ops fo_sig fo_terms fo_logic fo_sat Sig2_SigSSn1.
 
+Import fol_notations.
+
 Set Implicit Arguments.
 
 (* * Expanding from Σ=({f^n};{P^1}) to any signature *)

--- a/theories/TRAKHTENBROT/Sign_Sig.v
+++ b/theories/TRAKHTENBROT/Sign_Sig.v
@@ -18,6 +18,8 @@ From Undecidability.Shared.Libs.DLW.Vec
 From Undecidability.TRAKHTENBROT
   Require Import notations utils fol_ops fo_sig fo_terms fo_logic fo_sat.
 
+Import fol_notations.
+
 Set Implicit Arguments.
 
 (* * From Σ=(ø;{R^n}) to any signature *)

--- a/theories/TRAKHTENBROT/Sign_Sig2.v
+++ b/theories/TRAKHTENBROT/Sign_Sig2.v
@@ -22,6 +22,8 @@ From Undecidability.TRAKHTENBROT
   Require Import notations decidable fol_ops fo_sig fo_terms fo_logic fo_sat
                  membership hfs reln_hfs.
 
+Import fol_notations.
+
 Set Implicit Arguments.
 
 (* * From Σ=(ø;{R^n}) to Σ=(ø;{R^2}) *)
@@ -47,8 +49,8 @@ Section Sign_Sig2_encoding.
       | ⊥             => ⊥
       | fol_atom _  v => Σ2_is_tuple_in r (vec_map (@Σrel_var _) v)
       | fol_bin b A B => fol_bin b (Σn_Σ2 d r A) (Σn_Σ2 d r B)
-      | fol_quant fol_fa A  => ∀' 0 ∈ (S d) ⤑ Σn_Σ2 (S d) (S r) A
-      | fol_quant fol_ex A  => ∃' 0 ∈ (S d) ⟑ Σn_Σ2 (S d) (S r) A
+      | fol_quant fol_fa A  => ∀ 0 ∈ (S d) ⤑ Σn_Σ2 (S d) (S r) A
+      | fol_quant fol_ex A  => ∃ 0 ∈ (S d) ⟑ Σn_Σ2 (S d) (S r) A
      end.
 
   Variable (X : Type) (M2 : fo_model Σ2 X).

--- a/theories/TRAKHTENBROT/discrete.v
+++ b/theories/TRAKHTENBROT/discrete.v
@@ -18,6 +18,8 @@ From Undecidability.Shared.Libs.DLW.Vec
 From Undecidability.TRAKHTENBROT
   Require Import notations decidable gfp fol_ops fo_sig fo_terms fo_logic fo_definable fo_sat.
 
+Import fol_notations.
+
 Set Implicit Arguments.
 
 Local Notation " e '#>' x " := (vec_pos e x).

--- a/theories/TRAKHTENBROT/fo_congruence.v
+++ b/theories/TRAKHTENBROT/fo_congruence.v
@@ -18,6 +18,8 @@ From Undecidability.Shared.Libs.DLW.Vec
 From Undecidability.TRAKHTENBROT
   Require Import notations utils fol_ops fo_sig fo_terms fo_logic.
 
+Import fol_notations.
+
 Require Import Undecidability.Shared.ListAutomation.
 
 Set Implicit Arguments.
@@ -319,9 +321,9 @@ Section fol_congruence.
     Qed.
 
     Local Definition fol_equivalence := 
-            (∀' £0 ≡ £0)
-          ⟑ (∀'∀'∀' £2 ≡ £1 ⤑ £1 ≡ £0 ⤑ £2 ≡ £0)
-          ⟑ (∀'∀' £1 ≡ £0 ⤑ £0 ≡ £1).
+            (∀ £0 ≡ £0)
+          ⟑ (∀∀∀ £2 ≡ £1 ⤑ £1 ≡ £0 ⤑ £2 ≡ £0)
+          ⟑ (∀∀ £1 ≡ £0 ⤑ £0 ≡ £1).
 
     Local Fact fol_equivalence_syms : fol_syms fol_equivalence = nil.
     Proof.

--- a/theories/TRAKHTENBROT/fo_definable.v
+++ b/theories/TRAKHTENBROT/fo_definable.v
@@ -18,6 +18,8 @@ From Undecidability.Shared.Libs.DLW.Vec
 From Undecidability.TRAKHTENBROT
   Require Import notations utils fol_ops fo_sig fo_terms fo_logic.
 
+Import fol_notations.
+
 Set Implicit Arguments.
 
 (* * First order definability and closure properties *)

--- a/theories/TRAKHTENBROT/fo_enum.v
+++ b/theories/TRAKHTENBROT/fo_enum.v
@@ -19,6 +19,8 @@ From Undecidability.TRAKHTENBROT
   Require Import notations utils decidable enumerable
                  fol_ops fo_sig fo_terms fo_logic.
 
+Import fol_notations.
+
 Set Implicit Arguments.
 
 (* * Enumerability of the type of FO formulas *)

--- a/theories/TRAKHTENBROT/fo_logic.v
+++ b/theories/TRAKHTENBROT/fo_logic.v
@@ -41,15 +41,21 @@ Inductive fol_form (Σ : fo_signature) : Type :=
   | fol_bin   : fol_bop -> fol_form Σ -> fol_form Σ -> fol_form Σ 
   | fol_quant : fol_qop -> fol_form Σ -> fol_form Σ.
 
-Infix "⤑" := (fol_bin fol_imp) (at level 62, right associativity).
-Infix "⟑" := (fol_bin fol_conj) (at level 60, right associativity).
-Infix "⟇" := (fol_bin fol_disj) (at level 61, right associativity).
-Notation "∀' f" := (fol_quant fol_fa f) (at level 64, right associativity).
-Notation "∃' f" := (fol_quant fol_ex f) (at level 64, right associativity).
-Notation "x ↔ y" := ((x⤑y)⟑(y⤑x)) (at level 63, no associativity).
+Module fol_notations.
 
-Notation "£" := (in_var : nat -> fol_term _).
-Notation "⊥" := (fol_false _).
+  Infix "⤑" := (fol_bin fol_imp) (at level 62, right associativity).
+  Infix "⟑" := (fol_bin fol_conj) (at level 60, right associativity).
+  Infix "⟇" := (fol_bin fol_disj) (at level 61, right associativity).
+  Notation "∀ f" := (fol_quant fol_fa f) (at level 64, right associativity).
+  Notation "∃ f" := (fol_quant fol_ex f) (at level 64, right associativity).
+  Notation "x ↔ y" := ((x⤑y)⟑(y⤑x)) (at level 63, no associativity).
+
+  Notation "£" := (in_var : nat -> fol_term _).
+  Notation "⊥" := (fol_false _).
+
+End fol_notations.
+
+Import fol_notations.
 
 Section fol_subst.
 
@@ -229,12 +235,12 @@ Section fol_subst.
   Fact fol_subst_bigop c l A σ : (fol_bigop c A l)⦃σ⦄ = fol_bigop c (A⦃σ⦄) (map (fol_subst σ) l).
   Proof. induction l; simpl; f_equal; auto. Qed.
 
-  (* ∀' ... ∀' A  and  ∃' ... ∃' A *)
+  (* ∀ ... ∀ A  and  ∃ ... ∃ A *)
 
   Fixpoint fol_mquant q n (A : 𝔽) := 
     match n with 
       | 0   => A
-      | S n => fol_quant q (fol_mquant q n A)
+      | S n => (fol_quant q) (fol_mquant q n A)
     end.
 
   Fact fol_mquant_plus q a b A : fol_mquant q (a+b) A = fol_mquant q a (fol_mquant q b A).
@@ -246,7 +252,7 @@ Section fol_subst.
     apply fol_mquant_plus.
   Qed.
 
-  (* (Free) variables in ∀' ... ∀' A  and  ∃' ... ∃' A *)
+  (* (Free) variables in ∀ ... ∀ A  and  ∃ ... ∃ A *)
 
   Fact fol_vars_mquant q n (A : 𝔽) :
         fol_vars (fol_mquant q n A)
@@ -495,7 +501,7 @@ Section fol_semantics.
     replace (k+S n) with (S (k+n)) by lia; simpl; auto.
   Qed.
 
-  (* The semantics of ∀' ... ∀' A *)
+  (* The semantics of ∀ ... ∀ A *)
 
   Fact fol_sem_mforall n A φ : ⟪fol_mquant fol_fa n A⟫ φ 
                            <-> forall v : vec X n, ⟪A⟫ (env_vlift φ v).
@@ -509,7 +515,7 @@ Section fol_semantics.
       * intros H v; intros x; apply (H (x##v)).
   Qed.
 
-  (* The semantics of ∃' ... ∃' A *)
+  (* The semantics of ∃ ... ∃ A *)
 
   Fact fol_sem_mexists n A φ : ⟪fol_mquant fol_ex n A⟫ φ 
                            <-> exists v : vec X n, ⟪A⟫ (env_vlift φ v).

--- a/theories/TRAKHTENBROT/membership.v
+++ b/theories/TRAKHTENBROT/membership.v
@@ -18,6 +18,8 @@ From Undecidability.Shared.Libs.DLW.Vec
 From Undecidability.TRAKHTENBROT
   Require Import notations fol_ops fo_sig fo_terms fo_logic.
 
+Import fol_notations.
+
 Set Implicit Arguments.
 
 (* * The first order theory of membership *)
@@ -376,21 +378,21 @@ Section FOL_encoding.
   Definition Σ2_mem x y := @fol_atom Σ2 tt (£x##£y##ø).
   Infix "∈" := Σ2_mem.
 
-  Definition Σ2_non_empty l := ∃' 0 ∈ (1+l). 
-  Definition Σ2_incl x y := ∀' 0 ∈ (S x) ⤑ 0 ∈ (S y).
-  Definition Σ2_equiv x y := ∀' 0 ∈ (S x) ↔ 0 ∈ (S y).
+  Definition Σ2_non_empty l := ∃ 0 ∈ (1+l). 
+  Definition Σ2_incl x y := ∀ 0 ∈ (S x) ⤑ 0 ∈ (S y).
+  Definition Σ2_equiv x y := ∀ 0 ∈ (S x) ↔ 0 ∈ (S y).
 
   Infix "⊆" := Σ2_incl.
   Infix "≈" := Σ2_equiv.
 
-  Definition Σ2_transitive t := ∀'∀' 1 ∈ 0 ⤑ 0 ∈ (2+t) ⤑ 1 ∈ (2+t).
+  Definition Σ2_transitive t := ∀∀ 1 ∈ 0 ⤑ 0 ∈ (2+t) ⤑ 1 ∈ (2+t).
 
-  Definition Σ2_extensional := ∀'∀'∀' 2 ≈ 1 ⤑ 2 ∈ 0 ⤑ 1 ∈ 0.
+  Definition Σ2_extensional := ∀∀∀ 2 ≈ 1 ⤑ 2 ∈ 0 ⤑ 1 ∈ 0.
 
-  Definition Σ2_is_pair p x y := ∀' 0 ∈ (S p) ↔ 0 ≈ S x ⟇ 0 ≈ S y.
+  Definition Σ2_is_pair p x y := ∀ 0 ∈ (S p) ↔ 0 ≈ S x ⟇ 0 ≈ S y.
 
   Definition Σ2_is_opair p x y := 
-         ∃'∃'   Σ2_is_pair 1    (2+x) (2+x)
+         ∃∃   Σ2_is_pair 1    (2+x) (2+x)
             ⟑ Σ2_is_pair 0    (2+x) (2+y)
             ⟑ Σ2_is_pair (2+p) 1     0.
 
@@ -398,23 +400,23 @@ Section FOL_encoding.
   Proof. cbv; tauto. Qed.
 
   Definition Σ2_is_otriple p x y z := 
-          ∃'   Σ2_is_opair 0     (S x) (S y)
+          ∃   Σ2_is_opair 0     (S x) (S y)
             ⟑ Σ2_is_opair (S p)  0    (S z).
 
   Definition Σ2_is_otriple_in r x y z := 
-          ∃'   Σ2_is_otriple 0 (S x) (S y) (S z) 
+          ∃   Σ2_is_otriple 0 (S x) (S y) (S z) 
             ⟑ 0 ∈ (S r).
 
   Definition Σ2_has_otriples l :=
-        ∀'∀'∀'   2 ∈ (3+l) 
+        ∀∀∀   2 ∈ (3+l) 
                       ⤑ 1 ∈ (3+l) 
                       ⤑ 0 ∈ (3+l) 
-                      ⤑ ∃' Σ2_is_otriple 0 3 2 1.
+                      ⤑ ∃ Σ2_is_otriple 0 3 2 1.
 
   Fixpoint Σ2_is_tuple t n : vec nat n -> fol_form Σ2 :=
     match n with 
-      | 0       => fun _ => ∀' 0 ∈ (S t) ⤑ ⊥
-      | S n     => fun v => ∃' Σ2_is_opair (S t) (S (vec_head v)) 0 
+      | 0       => fun _ => ∀ 0 ∈ (S t) ⤑ ⊥
+      | S n     => fun v => ∃ Σ2_is_opair (S t) (S (vec_head v)) 0 
                             ⟑ Σ2_is_tuple 0 (vec_map S (vec_tail v))
     end.
 
@@ -438,7 +440,7 @@ Section FOL_encoding.
           destruct H2 as [ -> | [] ]; tauto.
   Qed. 
 
-  Definition Σ2_is_tuple_in r n v := ∃' @Σ2_is_tuple 0 n (vec_map S v) ⟑ 0 ∈ (S r).
+  Definition Σ2_is_tuple_in r n v := ∃ @Σ2_is_tuple 0 n (vec_map S v) ⟑ 0 ∈ (S r).
 
   Fact Σ2_is_tuple_in_vars r n v : incl (fol_vars (@Σ2_is_tuple_in r n v)) (r::vec_list v).
   Proof.
@@ -458,17 +460,17 @@ Section FOL_encoding.
 
   Definition Σ2_has_tuples l n :=
        fol_mquant fol_fa n ( (fol_vec_fa (vec_set_pos (fun p : pos n => pos2nat p ∈ (l+n))))
-                                         ⤑ ∃' Σ2_is_tuple 0 (vec_set_pos (fun p : pos n => S (pos2nat p)))).
+                                         ⤑ ∃ Σ2_is_tuple 0 (vec_set_pos (fun p : pos n => S (pos2nat p)))).
 
   Definition Σ2_is_tot n l s :=
        fol_mquant fol_fa n ( (fol_vec_fa (vec_set_pos (fun p : pos n => pos2nat p ∈ (l+n))))
-                                         ⤑ ∃'∃'∃' 2 ∈ ((3+l)+n) ⟑ 1 ∈ ((3+s)+n) ⟑ Σ2_is_opair 1 2 0 ⟑ @Σ2_is_tuple 0 n (vec_set_pos (fun p : pos n => 3+pos2nat p)) ).
+                                         ⤑ ∃∃∃ 2 ∈ ((3+l)+n) ⟑ 1 ∈ ((3+s)+n) ⟑ Σ2_is_opair 1 2 0 ⟑ @Σ2_is_tuple 0 n (vec_set_pos (fun p : pos n => 3+pos2nat p)) ).
 
 (*  Definition Σ2_is_tot l s :=
-    ∀' 0 ∈ (1+l) ⤑ ∃'∃' 0 ∈ (3+l) ⟑ 1 ∈ (3+s) ⟑ Σ2_is_opair 1 0 2. *)
+    ∀ 0 ∈ (1+l) ⤑ ∃∃ 0 ∈ (3+l) ⟑ 1 ∈ (3+s) ⟑ Σ2_is_opair 1 0 2. *)
 
   Definition Σ2_is_fun l s :=
-    ∀'∀'∀'∀'∀' 2 ∈ (5+l) ⤑ 1 ∈ (5+l) ⤑
+    ∀∀∀∀∀ 2 ∈ (5+l) ⤑ 1 ∈ (5+l) ⤑
           4 ∈ (5+s) ⤑ 3 ∈ (5+s) ⤑
           Σ2_is_opair 4 2 0 ⤑
           Σ2_is_opair 3 1 0 ⤑


### PR DESCRIPTION
Solving the conflicting notations with the `fol_notations` module